### PR TITLE
Agregar enlace a política de privacidad

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Esta es una implementación web responsiva (mobile-first) del Asistente de Diagn
 - 🌐 Funciona completamente offline (sin conexión a internet)
 - 🔄 Cuestionario completo de evaluación de síntomas de dengue
 - 📋 Resultados inmediatos con recomendaciones según los síntomas
+- 🔒 Página de [Política de Privacidad](privacidad.html) incluida
 
 ## Uso del Asistente
 

--- a/docs/dengue.html
+++ b/docs/dengue.html
@@ -43,6 +43,16 @@
             border-radius: 8px;
             box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
         }
+
+        .privacy-link {
+            margin-top: 8px;
+            font-size: 14px;
+        }
+
+        .privacy-link a {
+            color: #fff;
+            text-decoration: underline;
+        }
         
         h1 {
             font-size: 28px;
@@ -231,6 +241,7 @@
         <header>
             <h1>Asistente de Diagnóstico de Dengue</h1>
             <p>Responda las preguntas para evaluar sus síntomas</p>
+            <p class="privacy-link"><a href="privacidad.html">Política de Privacidad</a></p>
         </header>
         
         <div class="intro" id="intro-screen">

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,6 +14,7 @@
         <div class="app-container">
             <header class="app-header">
                 <h1>Asistente de Diagnóstico de Dengue</h1>
+                <p class="privacy-link"><a href="privacidad.html">Política de Privacidad</a></p>
             </header>
 
             <main id="chat-container" class="chat-container">

--- a/docs/style.css
+++ b/docs/style.css
@@ -40,6 +40,16 @@ body {
     margin: 0;
 }
 
+.privacy-link {
+    margin-top: 0.5rem;
+}
+
+.privacy-link a {
+    color: #fff;
+    text-decoration: underline;
+    font-size: 0.9rem;
+}
+
 /* Chat container */
 .chat-container {
     flex: 1 1 auto;


### PR DESCRIPTION
## Summary
- agregar enlace visible a la política de privacidad en la demo web
- actualizar estilos para el enlace
- mencionar la política en la documentación

## Testing
- `git status --short`